### PR TITLE
Fix token refresh on american vehicles

### DIFF
--- a/lib/controllers/american.controller.ts
+++ b/lib/controllers/american.controller.ts
@@ -18,7 +18,7 @@ export class AmericanController extends SessionController {
   private vehicles: Array<AmericanVehicle> = [];
 
   public async refreshAccessToken(): Promise<string> {
-    const shouldRefreshToken = Math.floor(+new Date() / 1000 - this.session.tokenExpiresAt) <= 10;
+    const shouldRefreshToken = Math.floor(Date.now() / 1000 - this.session.tokenExpiresAt) >= -10;
 
     if (this.session.refreshToken && shouldRefreshToken) {
       logger.debug('refreshing token');
@@ -33,7 +33,6 @@ export class AmericanController extends SessionController {
         },
         json: true,
       });
-
       this.session.accessToken = response.body.access_token;
       this.session.refreshToken = response.body.refresh_token;
       this.session.tokenExpiresAt = Math.floor(

--- a/lib/vehicles/american.vehicle.ts
+++ b/lib/vehicles/american.vehicle.ts
@@ -291,6 +291,7 @@ export default class AmericanVehicle extends Vehicle {
     if (tokenDelta <= 60) {
       logger.debug("Token is expiring soon, let's get a new one");
       await this.controller.refreshAccessToken();
+      options.headers.access_token = this.controller.session.accessToken;
     } else {
       logger.debug('Token is all good, moving on!');
     }


### PR DESCRIPTION
This PR fixes a problem with token refresh on American vehicles. There were two bugs causing refreshes to fail:

1. The if condition that checks for a stale token had a bug; I updated the code here to match the condition in European vehicles.
2. After the token is refreshed the old access token would be used instead of the new one since the header was already built (using getDefaultHeaders(). Code updated to modify the header before submitting the request.