### PR TITLE
Added vehicle.fullStatus for EU

### DIFF
--- a/__tests__/util.spec.ts
+++ b/__tests__/util.spec.ts
@@ -1,0 +1,13 @@
+import { tempCodeToCelsius, celciusToTempCode } from '../lib/util';
+
+describe('Utility', () => {
+  it('converts temp code to celsius', () => {
+    expect(tempCodeToCelsius('0H')).toEqual(14);
+    expect(tempCodeToCelsius('AH')).toEqual(19);
+  });
+
+  it('converts celsius to temp code', () => {
+    expect(celciusToTempCode(14)).toEqual('0H');
+    expect(celciusToTempCode(19)).toEqual('AH');
+  });
+});

--- a/debug.js
+++ b/debug.js
@@ -10,8 +10,11 @@ const apiCalls = [
   { name: 'start', value: 'start' },
   { name: 'odometer', value: 'odometer' },
   { name: 'stop', value: 'stop' },
-  { name: 'status (on bluelink cache)', value: 'status' },
-  { name: 'status refresh (fetch vehicle)', value: 'statusR' },
+  { name: 'status (on server cache)', value: 'status' },
+  { name: 'status (on server cache) unparsed', value: 'statusU' },
+  { name: 'status refresh (fetch from vehicle)', value: 'statusR' },
+  { name: 'full raw status (on server cache)', value: 'fullStatus' },
+  { name: 'full raw status refresh (fetch from vehicle)', value: 'fullStatusR' },
   { name: 'lock', value: 'lock' },
   { name: 'unlock', value: 'unlock' },
   { name: 'locate', value: 'locate' },
@@ -103,6 +106,20 @@ async function performCommand(command) {
           parsed: true
         });
         console.log('status remote : ' + JSON.stringify(statusR, null, 2));
+        break;
+      case 'fullStatus':
+        const fullStatus = await vehicle.fullStatus({
+          refresh: false,
+          parsed: false
+        });
+        console.log('full status cached : ' + JSON.stringify(fullStatus, null, 2));
+        break;
+      case 'fullStatusR':
+        const fullStatusR = await vehicle.fullStatus({
+          refresh: true,
+          parsed: false
+        });
+        console.log('full status remote : ' + JSON.stringify(fullStatusR, null, 2));
         break;
       case 'start':
         const startRes = await vehicle.start({

--- a/lib/controllers/american.controller.ts
+++ b/lib/controllers/american.controller.ts
@@ -18,7 +18,7 @@ export class AmericanController extends SessionController {
   private vehicles: Array<AmericanVehicle> = [];
 
   public async refreshAccessToken(): Promise<string> {
-    const shouldRefreshToken = Math.floor(+new Date() / 1000 - this.session.tokenExpiresAt) <= 10;
+    const shouldRefreshToken = Math.floor(Date.now() / 1000 - this.session.tokenExpiresAt) >= -10;
 
     if (this.session.refreshToken && shouldRefreshToken) {
       logger.debug('refreshing token');
@@ -33,7 +33,6 @@ export class AmericanController extends SessionController {
         },
         json: true,
       });
-
       this.session.accessToken = response.body.access_token;
       this.session.refreshToken = response.body.refresh_token;
       this.session.tokenExpiresAt = Math.floor(
@@ -102,7 +101,6 @@ export class AmericanController extends SessionController {
 
     data.enrolledVehicleDetails.forEach(vehicle => {
       const vehicleInfo = vehicle.vehicleDetails;
-
       const vehicleConfig = {
         nickname: vehicleInfo.nickName,
         name: vehicleInfo.nickName,

--- a/lib/controllers/canadian.controller.ts
+++ b/lib/controllers/canadian.controller.ts
@@ -1,5 +1,5 @@
 import got from 'got';
-import { AccountInfo, BlueLinkyConfig, PreferedDealer } from '../interfaces/common.interfaces';
+import { BlueLinkyConfig } from '../interfaces/common.interfaces';
 import { CA_ENDPOINTS, CLIENT_ORIGIN } from '../constants/canada';
 import { Vehicle } from '../vehicles/vehicle';
 import CanadianVehicle from '../vehicles/canadian.vehicle';
@@ -9,8 +9,6 @@ import logger from '../logger';
 import { VehicleRegisterOptions } from '../interfaces/common.interfaces';
 
 export class CanadianController extends SessionController {
-  private _preferredDealer: PreferedDealer | null = null;
-  private _accountInfo: AccountInfo | null = null;
 
   constructor(userConfig: BlueLinkyConfig) {
     super(userConfig);
@@ -89,33 +87,6 @@ export class CanadianController extends SessionController {
     } catch (err) {
       logger.debug(err);
       return this.vehicles;
-    }
-  }
-
-  //////////////////////////////////////////////////////////////////////////////
-  // Account
-  //////////////////////////////////////////////////////////////////////////////
-  // TODO: deprecated account specific data
-  public async myAccount(): Promise<AccountInfo> {
-    logger.info('Begin myAccount request');
-    try {
-      const response = await this.request(CA_ENDPOINTS.myAccount, {});
-      this._accountInfo = response.result as AccountInfo;
-      return this._accountInfo;
-    } catch (err) {
-      throw err.message;
-    }
-  }
-
-  // TODO: deprecated account specific data
-  public async preferedDealer(): Promise<PreferedDealer | null> {
-    logger.info('Begin preferedDealer request');
-    try {
-      const response = await this.request(CA_ENDPOINTS.preferedDealer, {});
-      this._preferredDealer = response.result as PreferedDealer;
-      return this._preferredDealer;
-    } catch (err) {
-      throw err.message;
     }
   }
 

--- a/lib/interfaces/common.interfaces.ts
+++ b/lib/interfaces/common.interfaces.ts
@@ -241,6 +241,9 @@ export interface FullVehicleStatus {
 }
 
 // TODO: remove
+// =======
+// Rough mapping of the raw status that might no be the same for all regions
+
 export interface RawVehicleStatus {
   lastStatusDate: string;
   dateTime: string;
@@ -335,17 +338,6 @@ export interface VehicleInfo {
   vin: string;
 }
 
-export interface VehicleFeatures {
-  seatHeatVent: {
-    drvSeatHeatOption: number;
-    astSeatHeatOption: number;
-    rlSeatHeatOption: number;
-    rrSeatHeatOption: number;
-  };
-  hvacTempType: number;
-  targetMinSoc: number;
-}
-
 export interface VehicleFeatureEntry {
   category: string;
   features: [
@@ -360,16 +352,6 @@ export interface VehicleFeatureEntry {
     }
   ];
 }
-export interface VehicleFeaturesModel {
-  features: [VehicleFeatureEntry];
-}
-
-export interface VehicleInfoResponse {
-  vehicleInfo: VehicleInfo;
-  features: VehicleFeatures;
-  featuresModel: VehicleFeaturesModel;
-  status: VehicleStatus;
-}
 
 // Location
 export interface VehicleLocation {
@@ -382,27 +364,6 @@ export interface VehicleLocation {
   };
   heading: number;
 }
-
-// TODO: remove
-export interface LegacyVehicleLocation {
-  accuracy: {
-    hdop: number;
-    pdop: number;
-  };
-  coord: {
-    alt: number;
-    lat: number;
-    lon: number;
-    type: number;
-  };
-  head: number;
-  speed: {
-    unit: number;
-    value: number;
-  };
-  time: string;
-}
-
 export interface VehicleOdometer {
   unit: number;
   value: number;
@@ -413,23 +374,8 @@ export interface VehicleStatusOptions {
   parsed: boolean;
 }
 
-// Vehicle Next Service
-export interface VehicleNextService {
-  msopServiceOdometer: number;
-  msopServiceOdometerUnit: number;
-  mtspServiceDate: string;
-  imatServiceOdometer: number;
-  imatServiceOdometerUnit: number;
-  mtitServiceDate: string;
-  currentOdometer: number;
-  currentOdometerUnit: number;
-  serviceOdometerDuration: number;
-  serviceDaysDuration: number;
-  serviceMonthsThreshold: number;
-}
 
 // VEHICLE COMMANDS /////////////////////////////////////////////
-
 export interface VehicleCommandResponse {
   responseCode: number; // 0 is success
   responseDesc: string;
@@ -459,63 +405,4 @@ export interface VehicleRegisterOptions {
   regId: string;
   id: string;
   generation: string;
-}
-
-// ACCOUNT //////////////////////////////////////////////////////
-
-// Account Info
-export interface Address {
-  street: string;
-  city: string;
-  province: string;
-  postalCode: string;
-}
-
-export interface AccountInfo {
-  firstName: string;
-  lastName: string;
-  notificationEmail: string;
-  phones: {
-    primary: string | null;
-    secondary: string | null;
-  };
-  addresses: {
-    primary: Address | null;
-    secondary: Address | null;
-  };
-  preference: {
-    odometerUnit: number;
-    climateUnit: string; // "C" / "F"
-    languageId: number;
-    maintenanceAlert: boolean;
-    preferredDealer: PreferedDealer | null;
-    promotionMessage: string | null;
-  };
-}
-
-// PreferedDealer
-export interface PreferedDealerHour {
-  dayCode: number;
-  startTime: string;
-  startTimeUnit: string;
-  endTime: string;
-  endTimeUnit: string;
-}
-
-export interface PreferedDealer {
-  dealerCode: string;
-  dealerName: string;
-  street: string;
-  province: string;
-  city: string;
-  postalCode: string;
-  tel: string;
-  fax: string;
-  fullAddress: string;
-  distance: string;
-  lat: string;
-  lng: string;
-  webSite: string;
-  salesHourList: [PreferedDealerHour];
-  serviceHourList: [PreferedDealerHour];
 }

--- a/lib/interfaces/common.interfaces.ts
+++ b/lib/interfaces/common.interfaces.ts
@@ -63,6 +63,183 @@ export interface VehicleStatus {
   };
 }
 
+// TODO: fix/update
+export interface FullVehicleStatus {
+  vehicleLocation: {
+    coord: { lat: number; lon: number; alt: number; type: number };
+    head: number;
+    speed: { value: number; unit: number };
+    accuracy: { hdop: number; pdop: number };
+    time: string;
+  };
+  odometer: { value: number, unit: number };
+  vehicleStatus: {
+    time: string;
+    airCtrlOn: boolean;
+    engine: boolean;
+    doorLock: boolean;
+    doorOpen: { frontRight: number; frontLeft: number; backLeft: number; backRight: number };
+    trunkOpen: boolean;
+    airTemp: { unit: number; hvacTempType: number; value: string };
+    defrost: boolean;
+    acc: boolean;
+    ign3: boolean;
+    hoodOpen: boolean;
+    transCond: boolean;
+    steerWheelHeat: number;
+    sideBackWindowHeat: number;
+    tirePressureLamp: {
+      tirePressureWarningLampAll: number;
+      tirePressureWarningLampFL: number;
+      tirePressureWarningLampFR: number;
+      tirePressureWarningLampRL: number;
+      tirePressureWarningLampRR: number;
+    };
+    battery: { batSoc: number; batState: number; };
+    evStatus: {
+      batteryCharge: boolean;
+      batteryStatus: number;
+      batteryPlugin: number;
+      remainTime2: { 
+        etc1: { value: number; unit: number; };
+        etc2: { value: number; unit: number; };
+        etc3: { value: number; unit: number; };
+        atc: { value: number; unit: number; };
+      };
+      drvDistance: [
+        {
+          rangeByFuel: {
+            gasModeRange: { value: number; unit: number };
+            evModeRange: { value: number; unit: number };
+            totalAvailableRange: { value: number; unit: number };
+          };
+          type: number;
+        }
+      ];
+      // "reservChargeInfos": {
+      //   "reservChargeInfo": {
+      //     "reservChargeInfoDetail": {
+      //       "reservInfo": {
+      //         "day": [
+      //           1,
+      //           2,
+      //           3,
+      //           4,
+      //           5
+      //         ],
+      //         "time": {
+      //           "time": "0800",
+      //           "timeSection": 0
+      //         }
+      //       },
+      //       "reservChargeSet": true,
+      //       "reservFatcSet": {
+      //         "defrost": false,
+      //         "airTemp": {
+      //           "value": "00H",
+      //           "unit": 0,
+      //           "hvacTempType": 1
+      //         },
+      //         "airCtrl": 0,
+      //         "heating1": 0
+      //       }
+      //     }
+      //   },
+      //   "offpeakPowerInfo": {
+      //     "offPeakPowerTime1": {
+      //       "starttime": {
+      //         "time": "1200",
+      //         "timeSection": 0
+      //       },
+      //       "endtime": {
+      //         "time": "1200",
+      //         "timeSection": 0
+      //       }
+      //     },
+      //     "offPeakPowerFlag": 1
+      //   },
+      //   "reserveChargeInfo2": {
+      //     "reservChargeInfoDetail": {
+      //       "reservInfo": {
+      //         "day": [
+      //           9
+      //         ],
+      //         "time": {
+      //           "time": "1200",
+      //           "timeSection": 0
+      //         }
+      //       },
+      //       "reservChargeSet": false,
+      //       "reservFatcSet": {
+      //         "defrost": false,
+      //         "airTemp": {
+      //           "value": "00H",
+      //           "unit": 0,
+      //           "hvacTempType": 1
+      //         },
+      //         "airCtrl": 0,
+      //         "heating1": 0
+      //       }
+      //     }
+      //   },
+      //   "reservFlag": 0,
+      //   "ect": {
+      //     "start": {
+      //       "day": 9,
+      //       "time": {
+      //         "time": "1200",
+      //         "timeSection": 0
+      //       }
+      //     },
+      //     "end": {
+      //       "day": 9,
+      //       "time": {
+      //         "time": "1200",
+      //         "timeSection": 0
+      //       }
+      //     }
+      //   },
+      //   "targetSOClist": [
+      //     {
+      //       "targetSOClevel": 90,
+      //       "dte": {
+      //         "rangeByFuel": {
+      //           "evModeRange": {
+      //             "value": 392,
+      //             "unit": 1
+      //           },
+      //           "totalAvailableRange": {
+      //             "value": 392,
+      //             "unit": 1
+      //           }
+      //         },
+      //         "type": 2
+      //       },
+      //       "plugType": 0
+      //     },
+      //     {
+      //       "targetSOClevel": 80,
+      //       "dte": {
+      //         "rangeByFuel": {
+      //           "evModeRange": {
+      //             "value": 345,
+      //             "unit": 1
+      //           },
+      //           "totalAvailableRange": {
+      //             "value": 345,
+      //             "unit": 1
+      //           }
+      //         },
+      //         "type": 2
+      //       },
+      //       "plugType": 1
+      //     }
+      //   ]
+      // }
+    };
+  }
+}
+
 // TODO: remove
 export interface RawVehicleStatus {
   lastStatusDate: string;

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,145 +1,41 @@
-export const getTempCode = (temperature: number): string => {
-  switch (temperature) {
-    case 14.0:
-      return '00H';
-    case 14.5:
-      return '01H';
-    case 15.0:
-      return '02H';
-    case 15.5:
-      return '03H';
-    case 16.0:
-      return '04H';
-    case 16.5:
-      return '05H';
-    case 17.0:
-      return '06H';
-    case 17.5:
-      return '07H';
-    case 18.0:
-      return '08H';
-    case 18.5:
-      return '09H';
-    case 19.0:
-      return '0AH';
-    case 19.5:
-      return '0BH';
-    case 20.0:
-      return '0CH';
-    case 20.5:
-      return '0DH';
-    case 21.0:
-      return '0EH';
-    case 21.5:
-      return '0FH';
-    case 22.0:
-      return '10H';
-    case 22.5:
-      return '11H';
-    case 23.0:
-      return '12H';
-    case 23.5:
-      return '13H';
-    case 24.0:
-      return '14H';
-    case 24.5:
-      return '15H';
-    case 25.0:
-      return '16H';
-    case 25.5:
-      return '17H';
-    case 26.0:
-      return '18H';
-    case 26.5:
-      return '19H';
-    case 27.0:
-      return '1AH';
-    case 27.5:
-      return '1BH';
-    case 28.0:
-      return '1CH';
-    case 28.5:
-      return '1DH';
-    case 29.0:
-      return '1EH';
-    case 29.5:
-      return '1FH';
-    case 30.0:
-      return '20H';
-    default:
-      throw new Error('temperature out of bounds! min: 14.0* max: 30*, max step: 0.5');
+const dec2hexString = (dec: number) => '0x' + dec.toString(16).substr(-4).toUpperCase();
+
+const floatRange = (start, stop, step) => {
+  const ranges: Array<number> = [];
+  for (let i=start; i<=stop; i+=step) {
+    ranges.push(i);
   }
+  return ranges;
+}
+
+// Converts Kia's stupid temp codes to celsius
+// From what I can tell it uses a hex index on a list of temperatures starting at 14c ending at 30c with an added H on the end,
+// I'm thinking it has to do with Heat/Cool H/C but needs to be tested, while the car is off, it defaults to 01H
+export const celciusToTempCode = (temperature: number): string => {
+  // create a range of floats
+  const tempRange = floatRange(14, 30, 0.5);
+
+  // get the index from the celcious degre
+  const tempCodeIndex = tempRange.indexOf(temperature);
+
+  // convert to hex
+  const hexCode = dec2hexString(tempCodeIndex);
+
+  // get the second param and stick an H on the end?
+  // this needs more testing I guess :P
+  return hexCode.split('x')[1].toUpperCase() + "H";
 };
 
-export const getTempFromCode = (code: string): number => {
-  switch (code) {
-    case '00H':
-      return 14.0;
-    case '01H':
-      return 14.5;
-    case '02H':
-      return 15.0;
-    case '03H':
-      return 15.5;
-    case '04H':
-      return 16.0;
-    case '05H':
-      return 16.5;
-    case '06H':
-      return 17.0;
-    case '07H':
-      return 17.5;
-    case '08H':
-      return 18.0;
-    case '09H':
-      return 18.5;
-    case '0AH':
-      return 19.0;
-    case '0BH':
-      return 19.5;
-    case '0CH':
-      return 20.0;
-    case '0DH':
-      return 20.5;
-    case '0EH':
-      return 21.0;
-    case '0FH':
-      return 21.5;
-    case '10H':
-      return 22.0;
-    case '11H':
-      return 22.0;
-    case '12H':
-      return 23.0;
-    case '13H':
-      return 23.5;
-    case '14H':
-      return 24.0;
-    case '15H':
-      return 24.5;
-    case '16H':
-      return 25.0;
-    case '17H':
-      return 25.5;
-    case '18H':
-      return 26.0;
-    case '19H':
-      return 26.5;
-    case '1AH':
-      return 27.0;
-    case '1BH':
-      return 27.5;
-    case '1CH':
-      return 28.0;
-    case '1DH':
-      return 28.5;
-    case '1EH':
-      return 29.0;
-    case '1FH':
-      return 29.5;
-    case '20H':
-      return 30.0;
-    default:
-      throw new Error('temperature out of bounds! min: 14.0* max: 30*, max step: 0.5');
-  }
+export const tempCodeToCelsius = (code: string): number => {
+  // get first part
+  const hexTempIndex = code[0]
+
+  // create a range
+  const tempRange = floatRange(14, 30, 0.5);
+
+  // get the index
+  const tempIndex = parseInt(hexTempIndex, 16);
+
+  // return the relevant celsius temp
+  return tempRange[tempIndex]; 
 };

--- a/lib/vehicles/american.vehicle.ts
+++ b/lib/vehicles/american.vehicle.ts
@@ -24,7 +24,7 @@ export default class AmericanVehicle extends Vehicle {
 
   constructor(public vehicleConfig: VehicleRegisterOptions, public controller: SessionController) {
     super(vehicleConfig, controller);
-    logger.debug(`US Vehicle ${this.vehicleConfig.id} created`);
+    logger.debug(`US Vehicle ${this.vehicleConfig.regId} created`);
   }
 
   private getDefaultHeaders(): RequestHeaders {
@@ -291,6 +291,7 @@ export default class AmericanVehicle extends Vehicle {
     if (tokenDelta <= 60) {
       logger.debug("Token is expiring soon, let's get a new one");
       await this.controller.refreshAccessToken();
+      options.headers.access_token = this.controller.session.accessToken;
     } else {
       logger.debug('Token is all good, moving on!');
     }

--- a/lib/vehicles/european.vehicle.ts
+++ b/lib/vehicles/european.vehicle.ts
@@ -14,7 +14,7 @@ import got from 'got';
 import logger from '../logger';
 import { Vehicle } from './vehicle';
 import { EuropeanController } from '../controllers/european.controller';
-import { getTempCode, getTempFromCode } from '../util';
+import { celciusToTempCode, tempCodeToCelsius } from '../util';
 import { EU_BASE_URL } from '../constants/europe';
 
 export default class EuropeanVehicle extends Vehicle {
@@ -50,7 +50,7 @@ export default class EuropeanVehicle extends Vehicle {
             defrost: config.defrost,
             heating1: config.windscreenHeating ? 1 : 0,
           },
-          tempCode: getTempCode(config.temperature),
+          tempCode: celciusToTempCode(config.temperature),
           unit: config.unit,
         },
         headers: {
@@ -265,7 +265,7 @@ export default class EuropeanVehicle extends Vehicle {
         sideMirrorHeat: false,
         rearWindowHeat: !!vehicleStatus?.sideBackWindowHeat,
         defrost: vehicleStatus?.defrost,
-        temperatureSetpoint: getTempFromCode(vehicleStatus?.airTemp?.value),
+        temperatureSetpoint: tempCodeToCelsius(vehicleStatus?.airTemp?.value),
         temperatureUnit: vehicleStatus?.airTemp?.unit,
       },
       engine: {

--- a/lib/vehicles/vehicle.ts
+++ b/lib/vehicles/vehicle.ts
@@ -1,5 +1,6 @@
 import {
   VehicleStatus,
+  FullVehicleStatus,
   VehicleLocation,
   VehicleOdometer,
   VehicleClimateOptions,
@@ -20,6 +21,9 @@ export abstract class Vehicle {
   abstract async status(
     input: VehicleStatusOptions
   ): Promise<VehicleStatus | RawVehicleStatus | null>;
+  abstract async fullStatus(
+    input: VehicleStatusOptions
+  ): Promise<FullVehicleStatus | null>;
   abstract async unlock(): Promise<string>;
   abstract async lock(): Promise<string>;
   abstract async start(config: VehicleClimateOptions | VehicleStartOptions): Promise<string>;
@@ -27,6 +31,7 @@ export abstract class Vehicle {
   abstract async location(): Promise<VehicleLocation | null>;
   abstract async odometer(): Promise<VehicleOdometer | null>;
 
+  public _fullStatus: FullVehicleStatus | null = null;
   public _status: VehicleStatus | RawVehicleStatus | null = null;
   public _location: VehicleLocation | null = null;
   public _odometer: VehicleOdometer | null = null;


### PR DESCRIPTION
I was missing a lot of raw server information, especially the last know location data as cached on the Bluelinky server. Being able to get the last known location from the server is important to check if the vehicle moved without always doing a vehicle refresh. It reduces API calls and usage of online data.

This pr creates a new function for vehicle.fullStatus(), with optional refresh from vehicle.

The result will give location, odometer and status with a single command. When refresh:true is used it will fetch the data from the vehicle.

The pr is only for EU, but I imagine it can easily be copied to the other regions as well.