### PR TITLE
Added vehicle.fullStatus for EU

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -10,8 +10,11 @@ const apiCalls = [
   { name: 'start', value: 'start' },
   { name: 'odometer', value: 'odometer' },
   { name: 'stop', value: 'stop' },
-  { name: 'status (on bluelink cache)', value: 'status' },
-  { name: 'status refresh (fetch vehicle)', value: 'statusR' },
+  { name: 'status (on server cache)', value: 'status' },
+  { name: 'status (on server cache) unparsed', value: 'statusU' },
+  { name: 'status refresh (fetch from vehicle)', value: 'statusR' },
+  { name: 'full raw status (on server cache)', value: 'fullStatus' },
+  { name: 'full raw status refresh (fetch from vehicle)', value: 'fullStatusR' },
   { name: 'lock', value: 'lock' },
   { name: 'unlock', value: 'unlock' },
   { name: 'locate', value: 'locate' },
@@ -103,6 +106,20 @@ async function performCommand(command) {
           parsed: true
         });
         console.log('status remote : ' + JSON.stringify(statusR, null, 2));
+        break;
+      case 'fullStatus':
+        const fullStatus = await vehicle.fullStatus({
+          refresh: false,
+          parsed: false
+        });
+        console.log('full status cached : ' + JSON.stringify(fullStatus, null, 2));
+        break;
+      case 'fullStatusR':
+        const fullStatusR = await vehicle.fullStatus({
+          refresh: true,
+          parsed: false
+        });
+        console.log('full status remote : ' + JSON.stringify(fullStatusR, null, 2));
         break;
       case 'start':
         const startRes = await vehicle.start({

--- a/lib/interfaces/common.interfaces.ts
+++ b/lib/interfaces/common.interfaces.ts
@@ -63,6 +63,183 @@ export interface VehicleStatus {
   };
 }
 
+// TODO: fix/update
+export interface FullVehicleStatus {
+  vehicleLocation: {
+    coord: { lat: number; lon: number; alt: number; type: number };
+    head: number;
+    speed: { value: number; unit: number };
+    accuracy: { hdop: number; pdop: number };
+    time: string;
+  };
+  odometer: { value: number, unit: number };
+  vehicleStatus: {
+    time: string;
+    airCtrlOn: boolean;
+    engine: boolean;
+    doorLock: boolean;
+    doorOpen: { frontRight: number; frontLeft: number; backLeft: number; backRight: number };
+    trunkOpen: boolean;
+    airTemp: { unit: number; hvacTempType: number; value: string };
+    defrost: boolean;
+    acc: boolean;
+    ign3: boolean;
+    hoodOpen: boolean;
+    transCond: boolean;
+    steerWheelHeat: number;
+    sideBackWindowHeat: number;
+    tirePressureLamp: {
+      tirePressureWarningLampAll: number;
+      tirePressureWarningLampFL: number;
+      tirePressureWarningLampFR: number;
+      tirePressureWarningLampRL: number;
+      tirePressureWarningLampRR: number;
+    };
+    battery: { batSoc: number; batState: number; };
+    evStatus: {
+      batteryCharge: boolean;
+      batteryStatus: number;
+      batteryPlugin: number;
+      remainTime2: { 
+        etc1: { value: number; unit: number; };
+        etc2: { value: number; unit: number; };
+        etc3: { value: number; unit: number; };
+        atc: { value: number; unit: number; };
+      };
+      drvDistance: [
+        {
+          rangeByFuel: {
+            gasModeRange: { value: number; unit: number };
+            evModeRange: { value: number; unit: number };
+            totalAvailableRange: { value: number; unit: number };
+          };
+          type: number;
+        }
+      ];
+      // "reservChargeInfos": {
+      //   "reservChargeInfo": {
+      //     "reservChargeInfoDetail": {
+      //       "reservInfo": {
+      //         "day": [
+      //           1,
+      //           2,
+      //           3,
+      //           4,
+      //           5
+      //         ],
+      //         "time": {
+      //           "time": "0800",
+      //           "timeSection": 0
+      //         }
+      //       },
+      //       "reservChargeSet": true,
+      //       "reservFatcSet": {
+      //         "defrost": false,
+      //         "airTemp": {
+      //           "value": "00H",
+      //           "unit": 0,
+      //           "hvacTempType": 1
+      //         },
+      //         "airCtrl": 0,
+      //         "heating1": 0
+      //       }
+      //     }
+      //   },
+      //   "offpeakPowerInfo": {
+      //     "offPeakPowerTime1": {
+      //       "starttime": {
+      //         "time": "1200",
+      //         "timeSection": 0
+      //       },
+      //       "endtime": {
+      //         "time": "1200",
+      //         "timeSection": 0
+      //       }
+      //     },
+      //     "offPeakPowerFlag": 1
+      //   },
+      //   "reserveChargeInfo2": {
+      //     "reservChargeInfoDetail": {
+      //       "reservInfo": {
+      //         "day": [
+      //           9
+      //         ],
+      //         "time": {
+      //           "time": "1200",
+      //           "timeSection": 0
+      //         }
+      //       },
+      //       "reservChargeSet": false,
+      //       "reservFatcSet": {
+      //         "defrost": false,
+      //         "airTemp": {
+      //           "value": "00H",
+      //           "unit": 0,
+      //           "hvacTempType": 1
+      //         },
+      //         "airCtrl": 0,
+      //         "heating1": 0
+      //       }
+      //     }
+      //   },
+      //   "reservFlag": 0,
+      //   "ect": {
+      //     "start": {
+      //       "day": 9,
+      //       "time": {
+      //         "time": "1200",
+      //         "timeSection": 0
+      //       }
+      //     },
+      //     "end": {
+      //       "day": 9,
+      //       "time": {
+      //         "time": "1200",
+      //         "timeSection": 0
+      //       }
+      //     }
+      //   },
+      //   "targetSOClist": [
+      //     {
+      //       "targetSOClevel": 90,
+      //       "dte": {
+      //         "rangeByFuel": {
+      //           "evModeRange": {
+      //             "value": 392,
+      //             "unit": 1
+      //           },
+      //           "totalAvailableRange": {
+      //             "value": 392,
+      //             "unit": 1
+      //           }
+      //         },
+      //         "type": 2
+      //       },
+      //       "plugType": 0
+      //     },
+      //     {
+      //       "targetSOClevel": 80,
+      //       "dte": {
+      //         "rangeByFuel": {
+      //           "evModeRange": {
+      //             "value": 345,
+      //             "unit": 1
+      //           },
+      //           "totalAvailableRange": {
+      //             "value": 345,
+      //             "unit": 1
+      //           }
+      //         },
+      //         "type": 2
+      //       },
+      //       "plugType": 1
+      //     }
+      //   ]
+      // }
+    };
+  }
+}
+
 // TODO: remove
 export interface RawVehicleStatus {
   lastStatusDate: string;

--- a/lib/vehicles/vehicle.ts
+++ b/lib/vehicles/vehicle.ts
@@ -1,5 +1,6 @@
 import {
   VehicleStatus,
+  FullVehicleStatus,
   VehicleLocation,
   VehicleOdometer,
   VehicleClimateOptions,
@@ -20,6 +21,9 @@ export abstract class Vehicle {
   abstract async status(
     input: VehicleStatusOptions
   ): Promise<VehicleStatus | RawVehicleStatus | null>;
+  abstract async fullStatus(
+    input: VehicleStatusOptions
+  ): Promise<FullVehicleStatus | null>;
   abstract async unlock(): Promise<string>;
   abstract async lock(): Promise<string>;
   abstract async start(config: VehicleClimateOptions | VehicleStartOptions): Promise<string>;
@@ -27,6 +31,7 @@ export abstract class Vehicle {
   abstract async location(): Promise<VehicleLocation | null>;
   abstract async odometer(): Promise<VehicleOdometer | null>;
 
+  public _fullStatus: FullVehicleStatus | null = null;
   public _status: VehicleStatus | RawVehicleStatus | null = null;
   public _location: VehicleLocation | null = null;
   public _odometer: VehicleOdometer | null = null;


### PR DESCRIPTION
I was missing a lot of raw server information, especially the last know location data as cached on the Bluelinky server. Being able to get the last known location from the server is important to check if the vehicle moved without always doing a vehicle refresh. It reduces API calls and usage of online data.

This pr creates a new function for vehicle.fullStatus(), with optional refresh from vehicle.

The result will give location, odometer and status with a single command. When refresh:true is used it will fetch the data from the vehicle.

The pr is only for EU, but I imagine it can easily be copied to the other regions as well.

Edit: I'm a complete noob on TS and using git for collaboration. I'm kind of clueless on how to do these pr's accross forks and branches. So this pr is sort of a mess, but I hope you can work it out. I would suggest to also add fullStatus to CA and US regions ,just for generic compatibility sake (even though it would not add any benefit from an api rate limiting perspective)