### PR TITLE
EU : Adding a language option

### DIFF
--- a/src/constants/europe.ts
+++ b/src/constants/europe.ts
@@ -5,6 +5,10 @@ export const EU_BASE_URL = `https://${EU_API_HOST}`;
 export const EU_CLIENT_ID = '6d477c38-3ca4-4cf3-9557-2a1929a94654';
 export const EU_APP_ID = '99cfff84-f4e2-4be8-a5ed-e5b755eb6581';
 
+export type EULanguages = 'cs'|'da'|'nl'|'en'|'fi'|'fr'|'de'|'it'|'pl'|'hu'|'no'|'sk'|'es'|'sv';
+export const EU_LANGUAGES: EULanguages[] = ['cs', 'da', 'nl', 'en', 'fi', 'fr', 'de', 'it', 'pl', 'hu', 'no', 'sk', 'es', 'sv'];
+export const DEFAULT_LANGUAGE: EULanguages = 'en';
+
 export const EU_ENDPOINTS = {
   session: `${EU_BASE_URL}/api/v1/user/oauth2/authorize?response_type=code&state=test&client_id=${EU_CLIENT_ID}&redirect_uri=${EU_BASE_URL}/api/v1/user/oauth2/redirect`,
   login: `${EU_BASE_URL}/api/v1/user/signin`,

--- a/src/controllers/controller.ts
+++ b/src/controllers/controller.ts
@@ -2,7 +2,7 @@ import { Vehicle } from '../vehicles/vehicle';
 import { Session } from '../interfaces/common.interfaces';
 import { BlueLinkyConfig } from '../interfaces/common.interfaces';
 // changed this to interface so we can have option things?
-export abstract class SessionController {
+export abstract class SessionController<T extends BlueLinkyConfig = BlueLinkyConfig> {
   abstract login(): Promise<string>;
   abstract logout(): Promise<string>;
   abstract getVehicles(): Promise<Array<Vehicle>>;
@@ -14,9 +14,9 @@ export abstract class SessionController {
     deviceId: '',
     tokenExpiresAt: 0,
   };
-  public userConfig: BlueLinkyConfig;
+  public readonly userConfig: T;
 
-  constructor(userConfig: BlueLinkyConfig) {
+  constructor(userConfig: T) {
     this.userConfig = userConfig;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { AmericanController } from './controllers/american.controller';
-import { EuropeanController } from './controllers/european.controller';
+import { EuropeanController, EuropeBlueLinkyConfig } from './controllers/european.controller';
 import { CanadianController } from './controllers/canadian.controller';
 import { SessionController } from './controllers/controller';
 import { EventEmitter } from 'events';
@@ -22,7 +22,7 @@ class BlueLinky extends EventEmitter {
     vehicleId: undefined,
   };
 
-  constructor(config: BlueLinkyConfig) {
+  constructor(config: BlueLinkyConfig|EuropeBlueLinkyConfig) {
     super();
 
     switch (config.region) {

--- a/src/interfaces/common.interfaces.ts
+++ b/src/interfaces/common.interfaces.ts
@@ -1,8 +1,10 @@
+import { REGIONS } from '../constants';
+
 // config
 export interface BlueLinkyConfig {
   username: string | undefined;
   password: string | undefined;
-  region: string | undefined;
+  region: REGIONS | undefined;
   autoLogin?: boolean;
   pin: string | undefined;
   vin?: string | undefined;


### PR DESCRIPTION
Some EU users reported having troubles with the mobile app switching to `en` when using bluelinky or kuvork.

This should do the trick.