### PR TITLE
CA - Start command always return a failure

### DIFF
--- a/__tests__/vehicle.spec.ts
+++ b/__tests__/vehicle.spec.ts
@@ -199,6 +199,88 @@ describe('CanadianVehicle', () => {
     const response = await vehicle.lock();
     expect(response).toEqual('Lock successful');
   });
+  it('call start command succesfully', async () => {
+    // default session with a valid token
+    vehicle.controller.session = {
+      accessToken: 'JEST_TOKEN',
+      refreshToken: 'JEST_TOKEN',
+      tokenExpiresAt: Date.now() / 1000 + 300,
+    };
+
+    gotMock.mockReturnValueOnce({
+      body: {
+        result: {
+          pAuth: 'test',
+        },
+        responseHeader: {
+          responseCode: 0,
+        },
+      },
+      statusCode: 200,
+      json: true,
+    });
+
+    gotMock.mockReturnValueOnce({
+      body: {
+        responseHeader: {
+          responseCode: 0,
+        },
+      },
+      statusCode: 200,
+      json: true,
+    });
+
+    const response = await vehicle.start({
+      airCtrl: false,
+      igniOnDuration: 10,
+      airTempvalue: 70,
+      defrost: false,
+      heating1: false,
+    });
+    expect(response).toEqual('Vehicle started!');
+  });
+
+  it('call start command with error', async () => {
+    // default session with a valid token
+    vehicle.controller.session = {
+      accessToken: 'JEST_TOKEN',
+      refreshToken: 'JEST_TOKEN',
+      tokenExpiresAt: Date.now() / 1000 + 300,
+    };
+
+    gotMock.mockReturnValueOnce({
+      body: {
+        result: {
+          pAuth: 'test',
+        },
+        responseHeader: {
+          responseCode: 0,
+        },
+      },
+      statusCode: 200,
+      json: true,
+    });
+
+    gotMock.mockReturnValueOnce({
+      body: {
+        responseHeader: {
+          responseCode: 1,
+          responseDesc: 'failed'
+        },
+      },
+      statusCode: 200,
+      json: true,
+    });
+
+    const response = await vehicle.start({
+      airCtrl: false,
+      igniOnDuration: 10,
+      airTempvalue: 70,
+      defrost: false,
+      heating1: false,
+    });
+    expect(response).toEqual('Failed to start vehicle');
+  });
 });
 
 describe('EuropeanVehicle', () => {

--- a/src/vehicles/canadian.vehicle.ts
+++ b/src/vehicles/canadian.vehicle.ts
@@ -159,7 +159,7 @@ export default class CanadianVehicle extends Vehicle {
 
       logger.debug(response);
 
-      if (response.statusCode === 200) {
+      if (response.responseHeader && response.responseHeader.responseCode === 0) {
         return 'Vehicle started!';
       }
 


### PR DESCRIPTION
Base the canadian Start command on the right request response field. 
The return of the method was based on the value of `response.statusCode`, which was not return by the `request` method.
Now, I look for the value of `response.responseHeader.responseCode`

**Extract of the logs**
Current: 
```
[2021-04-04 11:16:20] debug: {
  "responseHeader": {
    "responseCode": 0,
    "responseDesc": "Success"
  }
}
start : "Failed to start vehicle"
```

Now: 
```
[2021-04-04 11:22:41] debug: {
  "responseHeader": {
    "responseCode": 0,
    "responseDesc": "Success"
  }
}
start : "Vehicle started!"
```