### PR TITLE
Canadian status fix

### DIFF
--- a/src/vehicles/canadian.vehicle.ts
+++ b/src/vehicles/canadian.vehicle.ts
@@ -42,7 +42,7 @@ export default class CanadianVehicle extends Vehicle {
     try {
       const endpoint = statusConfig.refresh ? this.controller.environment.endpoints.remoteStatus : this.controller.environment.endpoints.status;
       const response = await this.request(endpoint, {});
-      const vehicleStatus = response.result;
+      const vehicleStatus = response.result?.status;
 
       if (response?.error) {
         throw response?.error?.errorDesc;

--- a/src/vehicles/canadian.vehicle.ts
+++ b/src/vehicles/canadian.vehicle.ts
@@ -90,7 +90,7 @@ export default class CanadianVehicle extends Vehicle {
           batteryCharge12v: vehicleStatus?.battery?.batSoc,
           batteryChargeHV: vehicleStatus?.evStatus?.batteryStatus,
         },
-        lastupdate: vehicleStatus?.time ? parseDate(vehicleStatus?.time) : null,
+        lastupdate: vehicleStatus?.time ? parseDate(vehicleStatus?.lastStatusDate) : null,
       };
 
       this._status = statusConfig.parsed ? parsedStatus : vehicleStatus;


### PR DESCRIPTION
The Canadian status results are seemingly wrapped in a dict of the form
{
“status”: <actual status data>
}

Previously we were trying to grab data directly out of the wrapper dict. The fix is just to grab the inner dict first.