### PR TITLE
Fixes the selector for getting the range on a US electric vehicle

### DIFF
--- a/src/vehicles/american.vehicle.ts
+++ b/src/vehicles/american.vehicle.ts
@@ -209,7 +209,7 @@ export default class AmericanVehicle extends Vehicle {
         ignition: vehicleStatus?.engine,
         accessory: vehicleStatus?.acc,
         // try ev range first then fallback to ice range
-        range: vehicleStatus.evStatus?.drvDistance[0]?.rangeByFuel.totalAvailableRange.value || vehicleStatus?.dte?.value,
+        range: vehicleStatus.evStatus?.drvDistance[0]?.rangeByFuel?.totalAvailableRange?.value || vehicleStatus?.dte?.value,
         charging: vehicleStatus?.evStatus?.batteryCharge,
         batteryCharge12v: vehicleStatus?.battery?.batSoc,
         batteryChargeHV: vehicleStatus?.evStatus?.batteryStatus,

--- a/src/vehicles/american.vehicle.ts
+++ b/src/vehicles/american.vehicle.ts
@@ -209,7 +209,7 @@ export default class AmericanVehicle extends Vehicle {
         ignition: vehicleStatus?.engine,
         accessory: vehicleStatus?.acc,
         // try ev range first then fallback to ice range
-        range: vehicleStatus.evStatus?.drvDistance[0]?.rangeByFuel?.totalAvailableRange?.value || vehicleStatus?.dte?.value,
+        range: vehicleStatus?.evStatus?.drvDistance[0]?.rangeByFuel?.totalAvailableRange?.value || vehicleStatus?.dte?.value,
         charging: vehicleStatus?.evStatus?.batteryCharge,
         batteryCharge12v: vehicleStatus?.battery?.batSoc,
         batteryChargeHV: vehicleStatus?.evStatus?.batteryStatus,

--- a/src/vehicles/american.vehicle.ts
+++ b/src/vehicles/american.vehicle.ts
@@ -209,7 +209,7 @@ export default class AmericanVehicle extends Vehicle {
         ignition: vehicleStatus?.engine,
         accessory: vehicleStatus?.acc,
         // try ev range first then fallback to ice range
-        range: vehicleStatus.evStatus?.drvDistance[0]?.totalAvailableRange.value || vehicleStatus?.dte?.value,
+        range: vehicleStatus.evStatus?.drvDistance[0]?.rangeByFuel.totalAvailableRange.value || vehicleStatus?.dte?.value,
         charging: vehicleStatus?.evStatus?.batteryCharge,
         batteryCharge12v: vehicleStatus?.battery?.batSoc,
         batteryChargeHV: vehicleStatus?.evStatus?.batteryStatus,


### PR DESCRIPTION
Fixes the selector for getting the range on a US electric vehicle. The selector was previously missing the `rangeByFuel` parameter when drilling down on the `evStatus` object and would throw undefined errors.

This is an excerpt from the unparsed status for my car (Hyundai Kona EV in the US) for reference:
      
      "drvDistance": [
          {
              "rangeByFuel": {
                  "gasModeRange": {
                      "unit": 3,
                      "value": 0.0
                  },
                  "totalAvailableRange": {
                      "unit": 3,
                      "value": 216.0
                  },
                  "evModeRange": {
                      "unit": 3,
                      "value": 216.0
                  }
              },
              "type": 2
          }
      ],