### PR TITLE
EU|KIA: fix auth when using new AuthId

### DIFF
--- a/src/constants/europe.ts
+++ b/src/constants/europe.ts
@@ -106,7 +106,7 @@ const getKiaEnvironment = (stampsTimeout?: number): EuropeanBrandEnvironment => 
     GCMSenderID: '345127537656',
     stamp: getStamp(`kia-${appId}`, stampsTimeout),
     brandAuthUrl({ language, serviceId, userId }) {
-      const newAuthClientId = 'f4d531c7-1043-444d-b09a-ad24bd913dd4';
+      const newAuthClientId = '572e0304-5f8d-4b4c-9dd5-41aa84eed160';
       return `https://eu-account.kia.com/auth/realms/eukiaidm/protocol/openid-connect/auth?client_id=${newAuthClientId}&scope=openid%20profile%20email%20phone&response_type=code&hkid_session_reset=true&redirect_uri=${baseUrl}/api/v1/user/integration/redirect/login&ui_locales=${language}&state=${serviceId}:${userId}`;
     }
   };

--- a/src/controllers/authStrategies/european.brandAuth.strategy.ts
+++ b/src/controllers/authStrategies/european.brandAuth.strategy.ts
@@ -31,8 +31,10 @@ export class EuropeanBrandAuthStrategy implements AuthStrategy {
 			json: true,
 			headers: stdHeaders
 		});
+		const brandAuthUrl = this.environment.brandAuthUrl({ language: this.language, userId, serviceId });
+		const parsedBrandUrl = Url.parse(brandAuthUrl, true);
 		const { body: authForm } = await got(
-			this.environment.brandAuthUrl({ language: this.language, userId, serviceId }), {
+			brandAuthUrl, {
 			cookieJar,
 			headers: stdHeaders
 		});
@@ -61,12 +63,49 @@ export class EuropeanBrandAuthStrategy implements AuthStrategy {
 			}
 			throw new Error('@EuropeanBrandAuthStrategy.login: Authentication failed, cannot retrieve error message');
 		}
-		const { url, body: htmlPage } = await got(redirectTo, {
+		const authResult = await got(redirectTo, {
 			cookieJar,
 			headers: stdHeaders
 		});
+		let url = authResult.url;
+		let htmlPage = authResult.body;
 		if(!url) {
 			throw new Error(`@EuropeanBrandAuthStrategy.login: after login redirection got stuck : ${htmlPage}`);
+		}
+		if(url.includes('login-actions/required-action')) {
+			const loginActionUrl = /action="([a-z0-9:/\-.?_=&;]*)"/gi.exec(htmlPage);
+			const loginActionCode = /name="code" value="(.*)"/gi.exec(htmlPage);
+			if (!loginActionUrl) {
+				throw new Error('@EuropeanBrandAuthStrategy.login: Cannot find login-actions url.');
+			}
+			if (!loginActionCode) {
+				throw new Error('@EuropeanBrandAuthStrategy.login: Cannot find login-actions code.');
+			}
+			const actionUrl = (loginActionUrl[1].startsWith('/')) ? `${parsedBrandUrl.protocol}//${parsedBrandUrl.host}${loginActionUrl[1]}` : loginActionUrl[1];
+			const loginActionForm = new URLSearchParams();
+			loginActionForm.append('code', loginActionCode[1]);
+			loginActionForm.append('accept', '');
+			const { headers: { location: loginActionRedirect }, body: AfterLoginActionAuthForm  } = await manageGot302(got.post(actionUrl, {
+				cookieJar,
+				body: loginActionForm.toString(),
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+					...stdHeaders
+				},
+			}));
+			if(!loginActionRedirect) {
+				const errorMessage = /<span class="kc-feedback-text">(.+)<\/span>/gm.exec(AfterLoginActionAuthForm);
+				if (errorMessage) {
+					throw new Error(`@EuropeanBrandAuthStrategy.login: Authentication action failed with message : ${errorMessage[1]}`);
+				}
+				throw new Error('@EuropeanBrandAuthStrategy.login: Authentication action failed, cannot retrieve error message');
+			}
+			const authResult = await got(loginActionRedirect, {
+				cookieJar,
+				headers: stdHeaders
+			});
+			url = authResult.url;
+			htmlPage = authResult.body;
 		}
 		const { intUserId: appUser } = Url.parse(url, true).query;
 		if (!appUser) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { REGION } from "./constants";
+import { REGION } from './constants';
 
 const dec2hexString = (dec: number) => '0x' + dec.toString(16).substr(-4).toUpperCase();
 


### PR DESCRIPTION
## :eyes:  What changed

- Kia & Hyundai released a new EU app
- This app use a new AuthId
- The authId triggers a new page on first login asking for permissions `Kia Connect would like to access the following information: phone number, user profile, email address, provided this in your Kia Accoun`
- Our code doesn't know what to do with this

## :wrench:  What's fixed

- Detect this step and auto acknowledge

## :warning:  Warnings

- Only tested with the new Kia ID, (Kia-eniro - France)
- Not tested on Hyundai (As reported the new Id might be `64621b96-0f0d-11ec-82a8-0242ac130003`)
- The Hyundai part is unchanged in this branch

## :book:  Side note

We can also ignore this and logout / login from the mobile app, this way the user will properly acknowledge from the app.