### PR TITLE
[FIX] Manage a very short date format (year - month)

### DIFF
--- a/__tests__/util.spec.ts
+++ b/__tests__/util.spec.ts
@@ -38,6 +38,10 @@ describe('Utility', () => {
     expect(parseDate('20210117')).toEqual(new Date('2021-01-17:00:00:00'));
   });
 
+  it('parseDate converts very shortdate to date', () => {
+    expect(parseDate('202101')).toEqual(new Date('2021-01-01:00:00:00'));
+  });
+
   it('addTime can add minutes to a date', () => {
     const start = new Date('2021-01-18:12:00:00');
     expect(addMinutes(start, 30)).toEqual(new Date('2021-01-18:12:30:00'));

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,7 +42,7 @@ export const celciusToTempCode = (region: REGION, temperature: number): string =
   return `${hexCode.split('x')[1].toUpperCase()}H`.padStart(3, '0');
 };
 
-export const tempCodeToCelsius = (region: REGION, code: string): number => { 
+export const tempCodeToCelsius = (region: REGION, code: string): number => {
   // create a range
   const { start, end, step } = REGION_STEP_RANGES[region];
   const tempRange = floatRange(start, end, step);
@@ -60,16 +60,19 @@ export const tempCodeToCelsius = (region: REGION, code: string): number => {
  * @returns The parsed date
  */
 export const parseDate = (str: string): Date => {
-	const year = parseInt(str.substring(0, 4));
-	const month = parseInt(str.substring(4, 6));
-	const day = parseInt(str.substring(6, 8));
+  const year = parseInt(str.substring(0, 4));
+  const month = parseInt(str.substring(4, 6));
+  if (str.length <= 6) {
+    return new Date(year, month - 1);
+  }
+  const day = parseInt(str.substring(6, 8));
   if (str.length <= 8) {
     return new Date(year, month - 1, day);
   }
-	const hour = parseInt(str.substring(8, 10));
-	const minute = parseInt(str.substring(10, 12));
-	const second = parseInt(str.substring(12, 14));
-	return new Date(year, month - 1, day, hour, minute, second);
+  const hour = parseInt(str.substring(8, 10));
+  const minute = parseInt(str.substring(10, 12));
+  const second = parseInt(str.substring(12, 14));
+  return new Date(year, month - 1, day, hour, minute, second);
 };
 
 const MILISECONDS_PER_SECOND = 1000;


### PR DESCRIPTION
## Related
- Issue #193 

## Changes
- Added a special case when parsing date
- Added a new test for this case