### PR TITLE
Add support for Europe CCS2 request (v2)

### DIFF
--- a/src/controllers/european.controller.ts
+++ b/src/controllers/european.controller.ts
@@ -34,6 +34,7 @@ interface EuropeanVehicleDescription {
   vehicleName: string;
   regDate: string;
   vehicleId: string;
+  ccuCCS2ProtocolSupport: number
 }
 
 export class EuropeanController extends SessionController<EuropeBlueLinkyConfig> {
@@ -297,6 +298,7 @@ export class EuropeanController extends SessionController<EuropeBlueLinkyConfig>
             id: v.vehicleId,
             vin: vehicleProfile.vinInfo[0].basic.vin,
             generation: vehicleProfile.vinInfo[0].basic.modelYear,
+            ccuCCS2ProtocolSupport: !!v.ccuCCS2ProtocolSupport
           } as VehicleRegisterOptions;
 
           logger.debug(`@EuropeController.getVehicles: Added vehicle ${vehicleConfig.id}`);

--- a/src/interfaces/common.interfaces.ts
+++ b/src/interfaces/common.interfaces.ts
@@ -439,6 +439,7 @@ export interface VehicleRegisterOptions {
   regId: string;
   id: string;
   generation: string;
+  ccuCCS2ProtocolSupport?: boolean;
 }
 
 export type DeepPartial<T> = {


### PR DESCRIPTION
As #283 seems to be stuck, I started all over again. Anyways, thanks @arteck for the preparatory work!

The `ccuCCS2ProtocolSupport` gets stored and is used to prefer the `/ccs2/carstatus/latest` over the `/status` API. I also added parsing the data into `VehicleStatus`, although I was not yet able to interpret every parameter from the old model.

While trying to implement the _refresh_ via `/ccs2/carstatus`, I got an error stating, that this is not yet available for the Europe region. So it might be able to add it in again at a later point in time.