### PR TITLE
Add support for Brazil

### DIFF
--- a/__tests__/controller.spec.ts
+++ b/__tests__/controller.spec.ts
@@ -2,8 +2,9 @@
 import got from 'got';
 
 import { AmericanController } from '../src/controllers/american.controller';
-import { EuropeanController } from '../src/controllers/european.controller';
+import { BrazilianController } from '../src/controllers/brazilian.controller';
 import { CanadianController } from '../src/controllers/canadian.controller';
+import { EuropeanController } from '../src/controllers/european.controller';
 
 jest.mock('got');
 
@@ -12,6 +13,7 @@ const getController = region => {
     US: AmericanController,
     EU: EuropeanController,
     CA: CanadianController,
+    BR: BrazilianController,
   };
 
   const controller = new referenceMap[region]({
@@ -23,7 +25,7 @@ const getController = region => {
     pin: '1234',
     vin: '4444444444444',
     vehicleId: undefined,
-    stampMode: 'LOCAL'
+    stampMode: 'LOCAL',
   });
 
   return controller;

--- a/__tests__/vehicle.spec.ts
+++ b/__tests__/vehicle.spec.ts
@@ -13,6 +13,9 @@ import { CanadianController } from '../src/controllers/canadian.controller';
 import AMERICAN_STATUS_MOCK from './mock/americanStatus.json';
 import EUROPE_STATUS_MOCK from './mock/europeStatus.json';
 
+import BrazilianVehicle from '../src/vehicles/brazilian.vehicle';
+import { BrazilianController } from '../src/controllers/brazilian.controller';
+
 jest.mock('got');
 
 const gotMock = got as any;
@@ -29,6 +32,10 @@ const referenceMap = {
   CA: {
     controller: CanadianController,
     vehicle: CanadianVehicle,
+  },
+  BR: {
+    controller: BrazilianController,
+    vehicle: BrazilianVehicle,
   },
 };
 
@@ -162,7 +169,6 @@ describe('CanadianVehicle', () => {
     expect(vehicle.controller.session.accessToken).toEqual('JEST_TOKEN');
     expect(vehicle.controller.session.tokenExpiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
     expect(vehicle.controller.session.tokenExpiresAt).toBeLessThan(Math.floor(Date.now() / 1000 + 20));
-
   });
 
   it('call lock commmand', async () => {
@@ -365,7 +371,7 @@ describe('EuropeanVehicle', () => {
   //   });
 
   //   gotMock.mockClear();
-    
+
   //   await vehicle.checkControlToken();
 
   //   // should update control token

--- a/debug.ts
+++ b/debug.ts
@@ -1,9 +1,9 @@
 /* eslint-disable */
 // TODO: add all calls from EU and CA
 
+import inquirer from 'inquirer';
 import config from './config.json';
 import BlueLinky from './src';
-import inquirer from 'inquirer';
 import { Vehicle } from './src/vehicles/vehicle';
 
 const apiCalls = [
@@ -45,7 +45,7 @@ const askForRegionInput = () => {
         type: 'list',
         name: 'region',
         message: 'What Region are you in?',
-        choices: ['CN', 'US', 'EU', 'CA', 'AU'],
+        choices: ['CN', 'US', 'EU', 'CA', 'AU', 'BR'],
       },
       {
         type: 'list',
@@ -112,9 +112,9 @@ async function performCommand(command) {
         break;
       case 'vehicles':
         const vehicles = await client.getVehicles();
-         const response = vehicles.map(v => {
+        const response = vehicles.map(v => {
           const { name, vin, nickname, regDate, generation } = v.vehicleConfig;
-          return { name, vin, nickname, regDate, generation};
+          return { name, vin, nickname, regDate, generation };
         });
         console.log('vehicles', JSON.stringify(response, null, 2));
         break;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // moved all the US constants to its own file, we can use this file for shared constants
 import {
-  getBrandEnvironment as getCABrandEnvironment,
+    getBrandEnvironment as getCABrandEnvironment,
   CanadianBrandEnvironment,
 } from './constants/canada';
 import {
@@ -15,6 +15,10 @@ import {
   getBrandEnvironment as getAUBrandEnvironment,
   AustraliaBrandEnvironment,
 } from './constants/australia';
+import {
+  BrazilBrandEnvironment,
+  getBrandEnvironment as getBRBrandEnvironment,
+} from './constants/brazil';
 
 import { Brand, VehicleStatusOptions } from './interfaces/common.interfaces';
 
@@ -27,15 +31,17 @@ export const ALL_ENDPOINTS = {
     getCNBrandEnvironment({ brand }).endpoints,
   AU: (brand: Brand): AustraliaBrandEnvironment['endpoints'] =>
     getAUBrandEnvironment({ brand }).endpoints,
+  BR: (brand: Brand): BrazilBrandEnvironment['endpoints'] => getBRBrandEnvironment(brand).endpoints,
 };
 
-export type REGION = 'US' | 'CA' | 'EU' | 'CN' | 'AU';
+export type REGION = 'US' | 'CA' | 'EU' | 'CN' | 'AU' | 'BR';
 export enum REGIONS {
   US = 'US',
   CA = 'CA',
   EU = 'EU',
   CN = 'CN',
   AU = 'AU',
+  BR = 'BR',
 }
 
 // ev stuffz

--- a/src/constants/brazil.ts
+++ b/src/constants/brazil.ts
@@ -1,0 +1,63 @@
+import { Brand } from '../interfaces/common.interfaces';
+
+export interface BrazilBrandEnvironment {
+  brand: Brand;
+  host: string;
+  baseUrl: string;
+  clientId: string;
+  appId: string;
+  endpoints: {
+    session: string;
+    login: string;
+    language: string;
+    redirectUri: string;
+    token: string;
+    integration: string;
+    silentSignIn: string;
+  };
+  basicToken: string;
+}
+
+const getEndpoints = (baseUrl: string, clientId: string): BrazilBrandEnvironment['endpoints'] => ({
+  session: `${baseUrl}/api/v1/user/oauth2/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(
+    `${baseUrl}/api/v1/user/oauth2/redirect`
+  )}&lang=pt`,
+  login: `${baseUrl}/api/v1/user/signin`,
+  language: `${baseUrl}/api/v1/user/language`,
+  redirectUri: `${baseUrl}/api/v1/user/oauth2/redirect`,
+  token: `${baseUrl}/api/v1/user/oauth2/token`,
+  integration: `${baseUrl}/api/v1/user/integrationinfo`,
+  silentSignIn: `${baseUrl}/api/v1/user/silentsignin`,
+});
+
+const getHyundaiEnvironment = (): BrazilBrandEnvironment => {
+  const host = 'br-ccapi.hyundai.com.br';
+  const baseUrl = `https://${host}`;
+  const clientId = '03f7df9b-7626-4853-b7bd-ad1e8d722bd5';
+  const appId = '513a491a-0d7c-4d6a-ac03-a2df127d73b0';
+  return {
+    brand: 'hyundai',
+    host,
+    baseUrl,
+    clientId,
+    appId,
+    endpoints: Object.freeze(getEndpoints(baseUrl, clientId)),
+    basicToken:
+      'Basic MDNmN2RmOWItNzYyNi00ODUzLWI3YmQtYWQxZThkNzIyYmQ1OnlRejJiYzZDbjhPb3ZWT1I3UkRXd3hUcVZ3V0czeUtCWUZEZzBIc09Yc3l4eVBsSA==',
+  };
+};
+
+const getKiaEnvironment = (): BrazilBrandEnvironment => {
+  throw new Error('Kia is currently not supported in the Brazil region.');
+};
+
+export const getBrandEnvironment = (brand: Brand): BrazilBrandEnvironment => {
+  switch (brand) {
+    case 'hyundai':
+      return Object.freeze(getHyundaiEnvironment());
+    case 'kia':
+      return Object.freeze(getKiaEnvironment());
+    default:
+      throw new Error(`Constructor ${brand} is not managed.`);
+  }
+};

--- a/src/controllers/brazilian.controller.ts
+++ b/src/controllers/brazilian.controller.ts
@@ -1,0 +1,327 @@
+import got, { GotInstance, GotJSONFn } from 'got';
+import { CookieJar } from 'tough-cookie';
+import { URLSearchParams } from 'url';
+import { BrazilBrandEnvironment, getBrandEnvironment } from '../constants/brazil';
+import { BlueLinkyConfig, Session, VehicleRegisterOptions } from '../interfaces/common.interfaces';
+import logger from '../logger';
+import { asyncMap, manageBluelinkyError, uuidV4 } from '../tools/common.tools';
+import BrazilianVehicle from '../vehicles/brazilian.vehicle';
+import { Vehicle } from '../vehicles/vehicle';
+import { SessionController } from './controller';
+
+export interface BrazilianBlueLinkyConfig extends BlueLinkyConfig {
+  region: 'BR';
+}
+
+interface BrazilianVehicleDescription {
+  nickname: string;
+  vehicleName: string;
+  regDate: string;
+  vehicleId: string;
+}
+
+export class BrazilianController extends SessionController<BrazilianBlueLinkyConfig> {
+  private _environment: BrazilBrandEnvironment;
+
+  public session: Session = {
+    accessToken: undefined,
+    refreshToken: undefined,
+    controlToken: undefined,
+    deviceId: uuidV4(),
+    tokenExpiresAt: 0,
+    controlTokenExpiresAt: 0,
+  };
+
+  private vehicles: Array<BrazilianVehicle> = [];
+
+  constructor(userConfig: BrazilianBlueLinkyConfig) {
+    super(userConfig);
+    this._environment = getBrandEnvironment(userConfig.brand);
+    logger.debug('BR Controller created');
+  }
+
+  public get environment(): BrazilBrandEnvironment {
+    return this._environment;
+  }
+
+  private get defaultHeaders() {
+    return {
+      'ccsp-device-id': this.session.deviceId,
+      'ccsp-application-id': this.environment.appId,
+      'ccsp-service-id': this.environment.clientId,
+      'User-Agent':
+        'BR_BlueLink/1.0.14 (com.hyundai.bluelink.br; build:10132; iOS 26.5.0) Alamofire/5.9.1',
+      'Content-Type': 'application/json; charset=UTF-8',
+      'Offset': (new Date().getTimezoneOffset() / 60).toFixed(2),
+    };
+  }
+
+  public async login(): Promise<string> {
+    try {
+      if (!this.userConfig.password || !this.userConfig.username) {
+        throw new Error('@BrazilController.login: username and password must be defined.');
+      }
+
+      // 1. Register device for push notifications to get deviceId
+      const genRanHex = (size: number) =>
+        [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
+
+      const notificationResponse = await got(
+        `${this.environment.baseUrl}/api/v1/spa/notifications/register`,
+        {
+          method: 'POST',
+          headers: {
+            'ccsp-service-id': this.environment.clientId,
+            'ccsp-application-id': this.environment.appId,
+            'Content-Type': 'application/json; charset=UTF-8',
+            'User-Agent': this.defaultHeaders['User-Agent'],
+          },
+          body: JSON.stringify({
+            pushRegId: genRanHex(64),
+            pushType: 'APNS',
+            uuid: this.session.deviceId,
+          }),
+        }
+      );
+
+      if (notificationResponse.statusCode === 200) {
+        const notifBody = JSON.parse(notificationResponse.body);
+        if (notifBody.resMsg?.deviceId) {
+          this.session.deviceId = notifBody.resMsg.deviceId;
+        }
+      }
+
+      const cookieJar = new CookieJar();
+      const webUserAgent =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148_CCS_APP_iOS';
+
+      // 2. Initialize session to get cookies
+      await got(this.environment.endpoints.session, {
+        method: 'GET',
+        headers: { 'User-Agent': webUserAgent },
+        cookieJar,
+      });
+
+      // 3. Sign In to get authorization code
+      const signinResponse = await got(this.environment.endpoints.login, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/plain;charset=UTF-8',
+          'User-Agent': webUserAgent,
+        },
+        body: JSON.stringify({
+          email: this.userConfig.username,
+          password: this.userConfig.password,
+          mobileNum: '',
+        }),
+        cookieJar,
+      });
+
+      const signinBody = JSON.parse(signinResponse.body);
+      if (signinResponse.statusCode !== 200 || !signinBody.redirectUrl) {
+        throw new Error(`Login failed: ${signinResponse.body}`);
+      }
+
+      const redirectUrl = signinBody.redirectUrl;
+      const parsedUrl = new URL(redirectUrl);
+      const code = parsedUrl.searchParams.get('code');
+
+      if (!code) {
+        throw new Error('Code not found in redirect URL');
+      }
+
+      // 4. Exchange code for tokens
+      const tokenFormData = new URLSearchParams();
+      tokenFormData.append('grant_type', 'authorization_code');
+      tokenFormData.append('code', code);
+      tokenFormData.append('redirect_uri', this.environment.endpoints.redirectUri);
+      tokenFormData.append('client_id', this.environment.clientId);
+
+      const tokenResponse = await got(this.environment.endpoints.token, {
+        method: 'POST',
+        headers: {
+          'Authorization': this.environment.basicToken,
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+          'User-Agent': this.defaultHeaders['User-Agent'],
+        },
+        body: tokenFormData.toString(),
+        throwHttpErrors: false,
+        cookieJar,
+      });
+
+      if (tokenResponse.statusCode !== 200) {
+        throw new Error(`Token exchange failed: ${tokenResponse.body}`);
+      }
+
+      const tokenBody = JSON.parse(tokenResponse.body);
+      this.session.accessToken = `Bearer ${tokenBody.access_token}`;
+      this.session.refreshToken = tokenBody.refresh_token;
+      this.session.tokenExpiresAt = Math.floor(Date.now() / 1000 + tokenBody.expires_in);
+
+      logger.debug('@BrazilController.login: Session defined properly');
+      return 'Login success';
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilController.login');
+    }
+  }
+
+  public async refreshAccessToken(): Promise<string> {
+    const shouldRefreshToken = Math.floor(Date.now() / 1000 - this.session.tokenExpiresAt) >= -10;
+
+    if (!this.session.refreshToken) {
+      return 'Need refresh token to refresh access token. Use login()';
+    }
+
+    if (!shouldRefreshToken) {
+      return 'Token not expired, no need to refresh';
+    }
+
+    const formData = new URLSearchParams();
+    formData.append('grant_type', 'refresh_token');
+    formData.append('redirect_uri', 'https://br-ccapi.hyundai.com.br/api/v1/user/oauth2/redirect');
+    formData.append('refresh_token', this.session.refreshToken);
+
+    try {
+      const response = await got(`${this.environment.baseUrl}/api/v1/user/oauth2/token`, {
+        method: 'POST',
+        headers: {
+          'Authorization': this.environment.basicToken,
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'User-Agent': this.defaultHeaders['User-Agent'],
+        },
+        body: formData.toString(),
+        throwHttpErrors: false,
+      });
+
+      if (response.statusCode !== 200) {
+        return `Refresh token failed: ${response.body}`;
+      }
+
+      const responseBody = JSON.parse(response.body);
+      this.session.accessToken = 'Bearer ' + responseBody.access_token;
+      this.session.tokenExpiresAt = Math.floor(Date.now() / 1000 + responseBody.expires_in);
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilController.refreshAccessToken');
+    }
+
+    return 'Token refreshed';
+  }
+
+  public async enterPin(): Promise<string> {
+    if (!this.session.accessToken) {
+      throw 'Token not set';
+    }
+
+    try {
+      const response = await got(`${this.environment.baseUrl}/api/v1/user/pin`, {
+        method: 'PUT',
+        headers: {
+          ...this.defaultHeaders,
+          'Authorization': this.session.accessToken,
+        },
+        body: {
+          deviceId: this.session.deviceId,
+          pin: this.userConfig.pin,
+        },
+        json: true,
+      });
+
+      this.session.controlToken = 'Bearer ' + response.body.controlToken;
+      this.session.controlTokenExpiresAt = Math.floor(
+        Date.now() / 1000 + response.body.expiresTime
+      );
+      return 'PIN entered OK';
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilController.enterPin');
+    }
+  }
+
+  public async getVehicles(): Promise<Array<Vehicle>> {
+    if (!this.session.accessToken) {
+      throw 'Token not set';
+    }
+
+    try {
+      const response = await got(`${this.environment.baseUrl}/api/v1/spa/vehicles`, {
+        method: 'GET',
+        headers: {
+          ...this.defaultHeaders,
+          'Authorization': this.session.accessToken,
+        },
+        json: true,
+      });
+
+      this.vehicles = await asyncMap<BrazilianVehicleDescription, BrazilianVehicle>(
+        response.body.resMsg.vehicles,
+        async v => {
+          const vehicleProfileReponse = await got(
+            `${this.environment.baseUrl}/api/v1/spa/vehicles/${v.vehicleId}/profile`,
+            {
+              method: 'GET',
+              headers: {
+                ...this.defaultHeaders,
+                'Authorization': this.session.accessToken,
+              },
+              json: true,
+            }
+          );
+
+          const vehicleProfile = vehicleProfileReponse.body.resMsg;
+
+          const vehicleConfig = {
+            nickname: v.nickname,
+            name: v.vehicleName,
+            regDate: v.regDate,
+            brandIndicator: 'H',
+            id: v.vehicleId,
+            vin: vehicleProfile.vinInfo[0].basic.vin,
+            generation: vehicleProfile.vinInfo[0].basic.modelYear,
+          } as VehicleRegisterOptions;
+
+          return new BrazilianVehicle(vehicleConfig, this);
+        }
+      );
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilController.getVehicles');
+    }
+
+    return this.vehicles;
+  }
+
+  public async logout(): Promise<string> {
+    return 'OK';
+  }
+
+  private async checkControlToken(): Promise<void> {
+    await this.refreshAccessToken();
+    if (this.session?.controlTokenExpiresAt !== undefined) {
+      if (!this.session.controlToken || Date.now() / 1000 > this.session.controlTokenExpiresAt) {
+        await this.enterPin();
+      }
+    }
+  }
+
+  public async getVehicleHttpService(): Promise<GotInstance<GotJSONFn>> {
+    await this.checkControlToken();
+    return got.extend({
+      baseUrl: this.environment.baseUrl,
+      headers: {
+        ...this.defaultHeaders,
+        'Authorization': this.session.controlToken,
+      },
+      json: true,
+    });
+  }
+
+  public async getApiHttpService(): Promise<GotInstance<GotJSONFn>> {
+    await this.refreshAccessToken();
+    return got.extend({
+      baseUrl: this.environment.baseUrl,
+      headers: {
+        ...this.defaultHeaders,
+        'Authorization': this.session.accessToken,
+      },
+      json: true,
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,13 +14,16 @@ import { SessionController } from './controllers/controller';
 import { Vehicle } from './vehicles/vehicle';
 import { AustraliaBlueLinkyConfig, AustraliaController } from './controllers/australia.controller';
 import AustraliaVehicle from './vehicles/australia.vehicle';
+import { BrazilianBlueLinkyConfig, BrazilianController } from './controllers/brazilian.controller';
+import BrazilianVehicle from './vehicles/brazilian.vehicle';
 
 type BluelinkyConfigRegions =
   | AmericanBlueLinkyConfig
   | CanadianBlueLinkyConfig
   | EuropeBlueLinkyConfig
   | ChineseBlueLinkConfig
-  | AustraliaBlueLinkyConfig;
+  | AustraliaBlueLinkyConfig
+  | BrazilianBlueLinkyConfig;
 
 const DEFAULT_CONFIG = {
   username: '',
@@ -44,6 +47,8 @@ export class BlueLinky<
     ? ChineseVehicle
     : REGION extends REGIONS.AU
     ? AustraliaVehicle
+    : REGION extends REGIONS.BR
+    ? BrazilianVehicle
     : EuropeanVehicle
 > extends EventEmitter {
   private controller: SessionController;
@@ -75,6 +80,9 @@ export class BlueLinky<
         break;
       case REGIONS.AU:
         this.controller = new AustraliaController(this.config as AustraliaBlueLinkyConfig);
+        break;
+      case REGIONS.BR:
+        this.controller = new BrazilianController(this.config as BrazilianBlueLinkyConfig);
         break;
       default:
         throw new Error('Your region is not supported yet.');

--- a/src/util.ts
+++ b/src/util.ts
@@ -32,6 +32,11 @@ const REGION_STEP_RANGES = {
     end: 27,
     step: 0.5,
   },
+  BR: {
+    start: 14,
+    end: 30,
+    step: 0.5,
+  },
 };
 
 // Converts Kia's stupid temp codes to celsius

--- a/src/vehicles/brazilian.vehicle.ts
+++ b/src/vehicles/brazilian.vehicle.ts
@@ -1,0 +1,646 @@
+import {
+  ChargeTarget,
+  DEFAULT_VEHICLE_STATUS_OPTIONS,
+  POSSIBLE_CHARGE_LIMIT_VALUES,
+  REGIONS,
+} from '../constants';
+import {
+  DeepPartial,
+  EVChargeModeTypes,
+  EVPlugTypes,
+  FullVehicleStatus,
+  RawVehicleStatus,
+  VehicleDayTrip,
+  VehicleLocation,
+  VehicleMonthTrip,
+  VehicleMonthlyReport,
+  VehicleOdometer,
+  VehicleRegisterOptions,
+  VehicleStartOptions,
+  VehicleStatus,
+  VehicleStatusOptions,
+  VehicleTargetSOC,
+  VehicleWindowsOptions,
+} from '../interfaces/common.interfaces';
+
+import got from 'got';
+import { BrazilianController } from '../controllers/brazilian.controller';
+import {
+  EUDatedDriveHistory,
+  EUDriveHistory,
+  EUPOIInformation,
+  historyDrivingPeriod,
+} from '../interfaces/european.interfaces';
+import logger from '../logger';
+import { ManagedBluelinkyError, manageBluelinkyError } from '../tools/common.tools';
+import { addMinutes, celciusToTempCode, parseDate, tempCodeToCelsius } from '../util';
+import { Vehicle } from './vehicle';
+
+export default class BrazilianVehicle extends Vehicle {
+  public region = REGIONS.BR;
+  public serverRates: {
+    max: number;
+    current: number;
+    reset?: Date;
+    updatedAt?: Date;
+  } = {
+    max: -1,
+    current: -1,
+  };
+
+  constructor(
+    public vehicleConfig: VehicleRegisterOptions,
+    public controller: BrazilianController
+  ) {
+    super(vehicleConfig, controller);
+    logger.debug(`BR Vehicle ${this.vehicleConfig.id} created`);
+  }
+
+  public async start(config: VehicleStartOptions): Promise<string> {
+    const http = await this.controller.getVehicleHttpService();
+    try {
+      const response = this.updateRates(
+        await http.post(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/control/engine`, {
+          body: {
+            action: 'start',
+            hvacType: 0,
+            options: {
+              defrost: config.defrost,
+              heating1: config.heatedFeatures ? 1 : 0,
+            },
+            tempCode: celciusToTempCode(REGIONS.BR, config.temperature),
+            unit: config.unit,
+          },
+        })
+      );
+      logger.info(`Climate started for vehicle ${this.vehicleConfig.id}`);
+      return response.body;
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.start');
+    }
+  }
+
+  public async stop(): Promise<string> {
+    const http = await this.controller.getVehicleHttpService();
+    try {
+      const response = this.updateRates(
+        await http.post(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/control/engine`, {
+          body: {
+            action: 'stop',
+            hvacType: 0,
+            options: {
+              defrost: true,
+              heating1: 1,
+            },
+            tempCode: '10H',
+            unit: 'C',
+          },
+        })
+      );
+      logger.info(`Climate stopped for vehicle ${this.vehicleConfig.id}`);
+      return response.body;
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.stop');
+    }
+  }
+
+  public async lock(): Promise<string> {
+    const http = await this.controller.getVehicleHttpService();
+    try {
+      const response = this.updateRates(
+        await http.post(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/control/door`, {
+          body: {
+            action: 'close',
+            deviceId: this.controller.session.deviceId,
+          },
+        })
+      );
+      if (response.statusCode === 200) {
+        logger.debug(`Vehicle ${this.vehicleConfig.id} locked`);
+        return 'Lock successful';
+      }
+      return 'Something went wrong!';
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.lock');
+    }
+  }
+
+  public async unlock(): Promise<string> {
+    const http = await this.controller.getVehicleHttpService();
+    try {
+      const response = this.updateRates(
+        await http.post(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/control/door`, {
+          body: {
+            action: 'open',
+            deviceId: this.controller.session.deviceId,
+          },
+        })
+      );
+
+      if (response.statusCode === 200) {
+        logger.debug(`Vehicle ${this.vehicleConfig.id} unlocked`);
+        return 'Unlock successful';
+      }
+
+      return 'Something went wrong!';
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.unlock');
+    }
+  }
+
+  public async setWindows(config: VehicleWindowsOptions): Promise<string> {
+    const http = await this.controller.getVehicleHttpService();
+    try {
+      const response = this.updateRates(
+        await http.post(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/control/windowcurtain`, {
+          body: config,
+        })
+      );
+      return response.body;
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.setWindows');
+    }
+  }
+
+  public async fullStatus(input: VehicleStatusOptions): Promise<FullVehicleStatus | null> {
+    const statusConfig = {
+      ...DEFAULT_VEHICLE_STATUS_OPTIONS,
+      ...input,
+    };
+
+    const http = await this.controller.getVehicleHttpService();
+    const apiClient = await this.controller.getApiHttpService();
+
+    try {
+      const vehicleStatusResponse = this.updateRates(
+        statusConfig.refresh
+          ? await http.get(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/status/latest`)
+          : await http.get(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/status`)
+      );
+      const locationResponse = this.updateRates(
+        await apiClient.get(`/api/v1/spa/vehicles/${this.vehicleConfig.id}/location/park`)
+      );
+      const odometer = await this.odometer();
+      if (!odometer) {
+        return null;
+      }
+
+      this._fullStatus = {
+        vehicleLocation: locationResponse.body.resMsg?.gpsDetail || locationResponse.body.resMsg,
+        odometer,
+        vehicleStatus: vehicleStatusResponse.body.resMsg,
+      };
+      return this._fullStatus;
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.fullStatus');
+    }
+  }
+
+  public async status(
+    input: VehicleStatusOptions
+  ): Promise<VehicleStatus | RawVehicleStatus | null> {
+    const statusConfig = {
+      ...DEFAULT_VEHICLE_STATUS_OPTIONS,
+      ...input,
+    };
+
+    const http = await this.controller.getVehicleHttpService();
+
+    try {
+      const cacheString = statusConfig.refresh ? '' : '/latest';
+      const response = this.updateRates(
+        await http.get(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/status${cacheString}`)
+      );
+      const vehicleStatus = response.body.resMsg;
+
+      const parsedStatus: VehicleStatus = {
+        chassis: {
+          hoodOpen: vehicleStatus?.hoodOpen,
+          trunkOpen: vehicleStatus?.trunkOpen,
+          locked: vehicleStatus.doorLock,
+          openDoors: {
+            frontRight: !!vehicleStatus?.doorOpen?.frontRight,
+            frontLeft: !!vehicleStatus?.doorOpen?.frontLeft,
+            backLeft: !!vehicleStatus?.doorOpen?.backLeft,
+            backRight: !!vehicleStatus?.doorOpen?.backRight,
+          },
+          tirePressureWarningLamp: {
+            rearLeft: !!vehicleStatus?.tirePressureLamp?.tirePressureLampRL,
+            frontLeft: !!vehicleStatus?.tirePressureLamp?.tirePressureLampFL,
+            frontRight: !!vehicleStatus?.tirePressureLamp?.tirePressureLampFR,
+            rearRight: !!vehicleStatus?.tirePressureLamp?.tirePressureLampRR,
+            all: !!vehicleStatus?.tirePressureLamp?.tirePressureWarningLampAll,
+          },
+        },
+        climate: {
+          active: vehicleStatus?.airCtrlOn,
+          steeringwheelHeat: !!vehicleStatus?.steerWheelHeat,
+          sideMirrorHeat: false,
+          rearWindowHeat: !!vehicleStatus?.sideBackWindowHeat,
+          defrost: vehicleStatus?.defrost,
+          temperatureSetpoint: tempCodeToCelsius(REGIONS.BR, vehicleStatus?.airTemp?.value),
+          temperatureUnit: vehicleStatus?.airTemp?.unit,
+        },
+        engine: {
+          ignition: vehicleStatus.engine,
+          accessory: vehicleStatus?.acc,
+          rangeGas:
+            vehicleStatus?.evStatus?.drvDistance[0]?.rangeByFuel?.gasModeRange?.value ??
+            vehicleStatus?.dte?.value,
+          range: vehicleStatus?.evStatus?.drvDistance[0]?.rangeByFuel?.totalAvailableRange?.value,
+          rangeEV: vehicleStatus?.evStatus?.drvDistance[0]?.rangeByFuel?.evModeRange?.value,
+          plugedTo: vehicleStatus?.evStatus?.batteryPlugin ?? EVPlugTypes.UNPLUGED,
+          charging: vehicleStatus?.evStatus?.batteryCharge,
+          estimatedCurrentChargeDuration: vehicleStatus?.evStatus?.remainTime2?.atc?.value,
+          estimatedFastChargeDuration: vehicleStatus?.evStatus?.remainTime2?.etc1?.value,
+          estimatedPortableChargeDuration: vehicleStatus?.evStatus?.remainTime2?.etc2?.value,
+          estimatedStationChargeDuration: vehicleStatus?.evStatus?.remainTime2?.etc3?.value,
+          batteryCharge12v: vehicleStatus?.battery?.batSoc,
+          batteryChargeHV: vehicleStatus?.evStatus?.batteryStatus,
+        },
+        lastupdate: vehicleStatus?.time ? parseDate(vehicleStatus?.time) : null,
+      };
+
+      if (!parsedStatus.engine.range) {
+        if (parsedStatus.engine.rangeEV || parsedStatus.engine.rangeGas) {
+          parsedStatus.engine.range =
+            (parsedStatus.engine.rangeEV ?? 0) + (parsedStatus.engine.rangeGas ?? 0);
+        }
+      }
+
+      this._status = statusConfig.parsed ? parsedStatus : vehicleStatus;
+
+      return this._status;
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.status');
+    }
+  }
+
+  public async odometer(): Promise<VehicleOdometer | null> {
+    const http = await this.controller.getVehicleHttpService();
+    try {
+      const response = this.updateRates(
+        await http.post(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/monthlyreport`, {
+          body: {
+            setRptMonth: toMonthDate({
+              year: new Date().getFullYear(),
+              month: new Date().getMonth() + 1,
+            }),
+          },
+        })
+      );
+      this._odometer = {
+        unit: 0,
+        value: response.body.resMsg?.odometer,
+      };
+      return this._odometer;
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.odometer');
+    }
+  }
+
+  public async location(): Promise<VehicleLocation> {
+    const http = await this.controller.getApiHttpService();
+    try {
+      const response = this.updateRates(
+        await http.get(`/api/v1/spa/vehicles/${this.vehicleConfig.id}/location/park`)
+      );
+
+      const data = response.body.resMsg?.coord
+        ? response.body.resMsg
+        : response.body.resMsg?.gpsDetail;
+      this._location = {
+        latitude: data?.coord?.lat,
+        longitude: data?.coord?.lon,
+        altitude: data?.coord?.alt,
+        speed: {
+          unit: data?.speed?.unit,
+          value: data?.speed?.value,
+        },
+        heading: data?.head,
+      };
+
+      return this._location;
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.location');
+    }
+  }
+
+  public async startCharge(): Promise<string> {
+    const http = await this.controller.getVehicleHttpService();
+    try {
+      const response = this.updateRates(
+        await http.post(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/control/charge`, {
+          body: {
+            action: 'start',
+            deviceId: this.controller.session.deviceId,
+          },
+        })
+      );
+
+      if (response.statusCode === 200) {
+        logger.debug(`Send start charge command to Vehicle ${this.vehicleConfig.id}`);
+        return 'Start charge successful';
+      }
+
+      throw 'Something went wrong!';
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.startCharge');
+    }
+  }
+
+  public async stopCharge(): Promise<string> {
+    const http = await this.controller.getVehicleHttpService();
+    try {
+      const response = this.updateRates(
+        await http.post(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/control/charge`, {
+          body: {
+            action: 'stop',
+            deviceId: this.controller.session.deviceId,
+          },
+        })
+      );
+
+      if (response.statusCode === 200) {
+        logger.debug(`Send stop charge command to Vehicle ${this.vehicleConfig.id}`);
+        return 'Stop charge successful';
+      }
+
+      throw 'Something went wrong!';
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.stopCharge');
+    }
+  }
+
+  public async monthlyReport(
+    month: { year: number; month: number } = {
+      year: new Date().getFullYear(),
+      month: new Date().getMonth() + 1,
+    }
+  ): Promise<DeepPartial<VehicleMonthlyReport> | undefined> {
+    const http = await this.controller.getVehicleHttpService();
+    try {
+      const response = this.updateRates(
+        await http.post(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/monthlyreport`, {
+          body: {
+            setRptMonth: toMonthDate(month),
+          },
+        })
+      );
+      const rawData = response.body.resMsg?.monthlyReport;
+      if (rawData) {
+        return {
+          start: rawData.ifo?.mvrMonthStart,
+          end: rawData.ifo?.mvrMonthEnd,
+          breakdown: rawData.breakdown,
+          driving: rawData.driving
+            ? {
+                distance: rawData.driving?.runDistance,
+                startCount: rawData.driving?.engineStartCount,
+                durations: {
+                  idle: rawData.driving?.engineIdleTime,
+                  drive: rawData.driving?.engineOnTime,
+                },
+              }
+            : undefined,
+          vehicleStatus: rawData.vehicleStatus
+            ? {
+                tpms: rawData.vehicleStatus?.tpmsSupport
+                  ? Boolean(rawData.vehicleStatus?.tpmsSupport)
+                  : undefined,
+                tirePressure: {
+                  all: rawData.vehicleStatus?.tirePressure?.tirePressureLampAll == '1',
+                },
+              }
+            : undefined,
+        };
+      }
+      return;
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.monthyReports');
+    }
+  }
+
+  public async tripInfo(date: {
+    year: number;
+    month: number;
+    day: number;
+  }): Promise<DeepPartial<VehicleDayTrip>[] | undefined>;
+  public async tripInfo(date?: {
+    year: number;
+    month: number;
+  }): Promise<DeepPartial<VehicleMonthTrip> | undefined>;
+
+  public async tripInfo(
+    date: { year: number; month: number; day?: number } = {
+      year: new Date().getFullYear(),
+      month: new Date().getMonth() + 1,
+    }
+  ): Promise<DeepPartial<VehicleDayTrip>[] | DeepPartial<VehicleMonthTrip> | undefined> {
+    const http = await this.controller.getApiHttpService();
+    try {
+      const perDay = Boolean(date.day);
+      const response = this.updateRates(
+        await http.post(`/api/v1/spa/vehicles/${this.vehicleConfig.id}/tripinfo`, {
+          body: {
+            setTripLatest: 10,
+            setTripMonth: !perDay ? toMonthDate(date) : undefined,
+            setTripDay: perDay ? toDayDate(date) : undefined,
+            tripPeriodType: perDay ? 1 : 0,
+          },
+        })
+      );
+
+      if (!perDay) {
+        const rawData = response.body.resMsg;
+        return {
+          days: Array.isArray(rawData?.tripDayList)
+            ? rawData?.tripDayList.map(day => ({
+                dayRaw: day.tripDayInMonth,
+                date: day.tripDayInMonth ? parseDate(day.tripDayInMonth) : undefined,
+                tripsCount: day.tripCntDay,
+              }))
+            : [],
+          durations: {
+            drive: rawData?.tripDrvTime,
+            idle: rawData?.tripIdleTime,
+          },
+          distance: rawData?.tripDist,
+          speed: {
+            avg: rawData?.tripAvgSpeed,
+            max: rawData?.tripMaxSpeed,
+          },
+        } as VehicleMonthTrip;
+      } else {
+        const rawData = response.body.resMsg.dayTripList;
+        if (rawData && Array.isArray(rawData)) {
+          return rawData.map(day => ({
+            dayRaw: day.tripDay,
+            tripsCount: day.dayTripCnt,
+            distance: day.tripDist,
+            durations: {
+              drive: day.tripDrvTime,
+              idle: day.tripIdleTime,
+            },
+            speed: {
+              avg: day.tripAvgSpeed,
+              max: day.tripMaxSpeed,
+            },
+            trips: Array.isArray(day.tripList)
+              ? day.tripList.map(trip => {
+                  const start = parseDate(`${day.tripDay}${trip.tripTime}`);
+                  return {
+                    timeRaw: trip.tripTime,
+                    start,
+                    end: addMinutes(start, trip.tripDrvTime),
+                    durations: {
+                      drive: trip.tripDrvTime,
+                      idle: trip.tripIdleTime,
+                    },
+                    speed: {
+                      avg: trip.tripAvgSpeed,
+                      max: trip.tripMaxSpeed,
+                    },
+                    distance: trip.tripDist,
+                  };
+                })
+              : [],
+          }));
+        }
+      }
+      return;
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.history');
+    }
+  }
+
+  public async driveHistory(period: historyDrivingPeriod = historyDrivingPeriod.DAY): Promise<
+    DeepPartial<{
+      cumulated: EUDriveHistory[];
+      history: EUDatedDriveHistory[];
+    }>
+  > {
+    const http = await this.controller.getApiHttpService();
+    try {
+      const response = await http.post(`/api/v1/spa/vehicles/${this.vehicleConfig.id}/drvhistory`, {
+        body: {
+          periodTarget: period,
+        },
+      });
+      return {
+        cumulated: response.body.resMsg.drivingInfo?.map(line => ({
+          period: line.drivingPeriod,
+          consumption: {
+            total: line.totalPwrCsp,
+            engine: line.motorPwrCsp,
+            climate: line.climatePwrCsp,
+            devices: line.eDPwrCsp,
+            battery: line.batteryMgPwrCsp,
+          },
+          regen: line.regenPwr,
+          distance: line.calculativeOdo,
+        })),
+        history: response.body.resMsg.drivingInfoDetail?.map(line => ({
+          period: line.drivingPeriod,
+          rawDate: line.drivingDate,
+          date: line.drivingDate ? parseDate(line.drivingDate) : undefined,
+          consumption: {
+            total: line.totalPwrCsp,
+            engine: line.motorPwrCsp,
+            climate: line.climatePwrCsp,
+            devices: line.eDPwrCsp,
+            battery: line.batteryMgPwrCsp,
+          },
+          regen: line.regenPwr,
+          distance: line.calculativeOdo,
+        })),
+      };
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.history');
+    }
+  }
+
+  public async getChargeTargets(): Promise<DeepPartial<VehicleTargetSOC>[] | undefined> {
+    const http = await this.controller.getVehicleHttpService();
+    try {
+      const response = this.updateRates(
+        await http.get(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/charge/target`)
+      );
+      const rawData = response.body.resMsg?.targetSOClist;
+      if (rawData && Array.isArray(rawData)) {
+        return rawData.map(rawSOC => ({
+          distance: rawSOC.drvDistance?.distanceType?.distanceValue,
+          targetLevel: rawSOC.targetSOClevel,
+          type: rawSOC.plugType,
+        }));
+      }
+      return;
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.getChargeTargets');
+    }
+  }
+
+  public async setChargeTargets(limits: { fast: ChargeTarget; slow: ChargeTarget }): Promise<void> {
+    const http = await this.controller.getVehicleHttpService();
+    if (
+      !POSSIBLE_CHARGE_LIMIT_VALUES.includes(limits.fast) ||
+      !POSSIBLE_CHARGE_LIMIT_VALUES.includes(limits.slow)
+    ) {
+      throw new ManagedBluelinkyError(
+        `Charge target values are limited to ${POSSIBLE_CHARGE_LIMIT_VALUES.join(', ')}`
+      );
+    }
+    try {
+      this.updateRates(
+        await http.post(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/charge/target`, {
+          body: {
+            targetSOClist: [
+              { plugType: EVChargeModeTypes.FAST, targetSOClevel: limits.fast },
+              { plugType: EVChargeModeTypes.SLOW, targetSOClevel: limits.slow },
+            ],
+          },
+        })
+      );
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.setChargeTargets');
+    }
+  }
+
+  public async setNavigation(poiInformations: EUPOIInformation[]): Promise<void> {
+    const http = await this.controller.getVehicleHttpService();
+    try {
+      this.updateRates(
+        await http.post(`/api/v2/spa/vehicles/${this.vehicleConfig.id}/location/routes`, {
+          body: {
+            deviceID: this.controller.session.deviceId,
+            poiInfoList: poiInformations,
+          },
+        })
+      );
+    } catch (err) {
+      throw manageBluelinkyError(err, 'BrazilVehicle.setNavigation');
+    }
+  }
+
+  private updateRates<T extends Record<string, unknown>>(resp: got.Response<T>): got.Response<T> {
+    if (resp.headers?.['x-ratelimit-limit']) {
+      this.serverRates.max = Number(resp.headers?.['x-ratelimit-limit']);
+      this.serverRates.current = Number(resp.headers?.['x-ratelimit-remaining']);
+      if (resp.headers?.['x-ratelimit-reset']) {
+        this.serverRates.reset = new Date(Number(`${resp.headers?.['x-ratelimit-reset']}000`));
+      }
+      this.serverRates.updatedAt = new Date();
+    }
+    return resp;
+  }
+}
+
+function toMonthDate(month: { year: number; month: number }) {
+  return `${month.year}${month.month.toString().padStart(2, '0')}`;
+}
+
+function toDayDate(date: { year: number; month: number; day?: number }) {
+  return date.day
+    ? `${toMonthDate(date)}${date.day.toString().padStart(2, '0')}`
+    : toMonthDate(date);
+}


### PR DESCRIPTION
### Description
Added support for the Brazil (BR) region. Hyundai vehicles in Brazil use a slightly different OAuth 2.0 flow directly with `br-ccapi.hyundai.com.br` and standard v1/v2 endpoints. Kia is currently unsupported in this region, so an explicit error is thrown if `kia` is selected as the brand.

##### Disclaimer: I've been mostly working with front end apps, so I may have missed something here or there. I've set this PR to allow edits by maintainers, so feel free to fix anything or let me know what needs to be changed! I was able to get all the info I wanted using the debug script, so hopefully, everything is fine!

### Testing
Successfully tested locally against a live Hyundai HB20 in Brazil:
- [x] Login & Token Refresh
- [x] `vehicle.status()`
- [x] `vehicle.odometer()`
- [x] `vehicle.location()`
- [x] Lock / Unlock
- [x] Remote Start / Stop
